### PR TITLE
Add DB repositories and SaaS bootstrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing = "0.1.41"
 tracing-appender = "0.2"
 tracing-core = "0.1.33"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite"] }
 url = "2.5"
 urlencoding = "2.1.3"
 uuid = "1.15.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,10 @@ use crate::{
 		initialize_services, Result,
 	},
 	models::{BlockChainType, Network, ScriptLanguage},
-	repositories::{
-		MonitorRepository, MonitorService, NetworkRepository, NetworkService, TriggerRepository,
-	},
+        repositories::{
+                MonitorRepository, MonitorService, NetworkRepository, NetworkService, TriggerRepository,
+                DbMonitorRepository, DbNetworkRepository, DbTriggerRepository,
+        },
 	services::{
 		blockchain::{ClientPool, ClientPoolTrait},
 		blockwatcher::{BlockTracker, BlockTrackerTrait, BlockWatcherService, FileBlockStorage},
@@ -208,21 +209,31 @@ async fn main() -> Result<()> {
 		return Ok(());
 	}
 
-	let (
-		filter_service,
-		trigger_execution_service,
-		active_monitors,
-		networks,
-		monitor_service,
-		network_service,
-		trigger_service,
-	) = initialize_services::<
-		MonitorRepository<NetworkRepository, TriggerRepository>,
-		NetworkRepository,
-		TriggerRepository,
-	>(None, None, None)
-	.await
-	.map_err(|e| anyhow::anyhow!("Failed to initialize services: {}. Please refer to the documentation quickstart ({}) on how to configure the service.", e, DOCUMENTATION_URL))?;
+        let saas_mode = std::env::var("SAAS_MODE").map(|v| v == "true").unwrap_or(false);
+        let (
+                filter_service,
+                trigger_execution_service,
+                active_monitors,
+                networks,
+                monitor_service,
+                network_service,
+                trigger_service,
+        ) = if saas_mode {
+                initialize_services::<
+                        DbMonitorRepository<DbNetworkRepository, DbTriggerRepository>,
+                        DbNetworkRepository,
+                        DbTriggerRepository,
+                >(None, None, None)
+                .await
+        } else {
+                initialize_services::<
+                        MonitorRepository<NetworkRepository, TriggerRepository>,
+                        NetworkRepository,
+                        TriggerRepository,
+                >(None, None, None)
+                .await
+        }
+        .map_err(|e| anyhow::anyhow!("Failed to initialize services: {}. Please refer to the documentation quickstart ({}) on how to configure the service.", e, DOCUMENTATION_URL))?;
 
 	// Pre-load all trigger scripts into memory at startup to reduce file I/O operations.
 	// This prevents repeated file descriptor usage during script execution and improves performance
@@ -687,12 +698,22 @@ async fn validate_configuration() {
 	info!("Validating configuration files...");
 
 	// Initialize services in validation mode to check configurations
-	match initialize_services::<
-		MonitorRepository<NetworkRepository, TriggerRepository>,
-		NetworkRepository,
-		TriggerRepository,
-	>(None, None, None)
-	.await
+        let saas_mode = std::env::var("SAAS_MODE").map(|v| v == "true").unwrap_or(false);
+        match if saas_mode {
+                initialize_services::<
+                        DbMonitorRepository<DbNetworkRepository, DbTriggerRepository>,
+                        DbNetworkRepository,
+                        DbTriggerRepository,
+                >(None, None, None)
+                .await
+        } else {
+                initialize_services::<
+                        MonitorRepository<NetworkRepository, TriggerRepository>,
+                        NetworkRepository,
+                        TriggerRepository,
+                >(None, None, None)
+                .await
+        }
 	{
 		Ok((_, _, active_monitors, networks, _, _, _)) => {
 			info!("✓ Core services initialized successfully");

--- a/src/repositories/db_monitor_repository.rs
+++ b/src/repositories/db_monitor_repository.rs
@@ -1,0 +1,127 @@
+use std::{collections::HashMap, env, marker::PhantomData, path::Path};
+
+use async_trait::async_trait;
+use sqlx::{sqlite::SqlitePool, Row};
+
+use crate::{
+    models::{Monitor, Network, Trigger},
+    repositories::{
+        error::RepositoryError,
+        network::NetworkRepository,
+        trigger::TriggerRepository,
+        MonitorRepository, MonitorRepositoryTrait, NetworkRepositoryTrait, NetworkService,
+        TriggerRepositoryTrait, TriggerService,
+    },
+};
+
+/// Database-backed repository for monitor configurations
+#[derive(Clone)]
+pub struct DbMonitorRepository<N: NetworkRepositoryTrait + Send + 'static, T: TriggerRepositoryTrait + Send + 'static> {
+    monitors: HashMap<String, Monitor>,
+    _network_repository: PhantomData<N>,
+    _trigger_repository: PhantomData<T>,
+}
+
+impl<N, T> DbMonitorRepository<N, T>
+where
+    N: NetworkRepositoryTrait + Send + Sync + 'static,
+    T: TriggerRepositoryTrait + Send + Sync + 'static,
+{
+    fn db_url(path: Option<&Path>) -> String {
+        if let Some(p) = path {
+            format!("sqlite://{}", p.display())
+        } else if let Ok(url) = env::var("DATABASE_URL") {
+            url
+        } else {
+            "sqlite://monitor.db".to_string()
+        }
+    }
+}
+
+#[async_trait]
+impl<N, T> MonitorRepositoryTrait<N, T> for DbMonitorRepository<N, T>
+where
+    N: NetworkRepositoryTrait + Send + Sync + 'static,
+    T: TriggerRepositoryTrait + Send + Sync + 'static,
+{
+    async fn new(
+        path: Option<&Path>,
+        network_service: Option<NetworkService<N>>,
+        trigger_service: Option<TriggerService<T>>,
+    ) -> Result<Self, RepositoryError> {
+        let monitors = Self::load_all(path, network_service, trigger_service).await?;
+        Ok(Self {
+            monitors,
+            _network_repository: PhantomData,
+            _trigger_repository: PhantomData,
+        })
+    }
+
+    async fn load_all(
+        path: Option<&Path>,
+        network_service: Option<NetworkService<N>>,
+        trigger_service: Option<TriggerService<T>>,
+    ) -> Result<HashMap<String, Monitor>, RepositoryError> {
+        let url = Self::db_url(path);
+        let pool = SqlitePool::connect(&url)
+            .await
+            .map_err(|e| RepositoryError::load_error("Failed to connect to database", Some(Box::new(e)), None))?;
+        let rows = sqlx::query("SELECT name, data FROM monitors")
+            .fetch_all(&pool)
+            .await
+            .map_err(|e| RepositoryError::load_error("Failed to load monitors", Some(Box::new(e)), None))?;
+        let mut monitors = HashMap::new();
+        for row in rows {
+            let name: String = row.try_get("name").map_err(|e| RepositoryError::load_error("Failed to load monitors", Some(Box::new(e)), None))?;
+            let data: String = row.try_get("data").map_err(|e| RepositoryError::load_error("Failed to load monitors", Some(Box::new(e)), None))?;
+            let monitor: Monitor = serde_json::from_str(&data).map_err(|e| RepositoryError::load_error("Failed to parse monitor", Some(Box::new(e)), None))?;
+            monitors.insert(name, monitor);
+        }
+
+        let networks = match network_service {
+            Some(service) => service.get_all(),
+            None => N::new(None).await?.get_all(),
+        };
+
+        let triggers = match trigger_service {
+            Some(service) => service.get_all(),
+            None => T::new(None).await?.get_all(),
+        };
+
+        MonitorRepository::<NetworkRepository, TriggerRepository>::validate_monitor_references(&monitors, &triggers, &networks)?;
+        Ok(monitors)
+    }
+
+    async fn load_from_path(
+        &self,
+        path: Option<&Path>,
+        network_service: Option<NetworkService<N>>,
+        trigger_service: Option<TriggerService<T>>,
+    ) -> Result<Monitor, RepositoryError> {
+        match path {
+            Some(p) => {
+                let monitor = Monitor::load_from_path(p).await.map_err(|e| RepositoryError::load_error("Failed to load monitors", Some(Box::new(e)), Some(HashMap::from([("path".to_string(), p.display().to_string())]))))?;
+                let networks = match network_service {
+                    Some(service) => service.get_all(),
+                    None => N::new(None).await?.get_all(),
+                };
+                let triggers = match trigger_service {
+                    Some(service) => service.get_all(),
+                    None => T::new(None).await?.get_all(),
+                };
+                let monitors = HashMap::from([(monitor.name.clone(), monitor.clone())]);
+                MonitorRepository::<NetworkRepository, TriggerRepository>::validate_monitor_references(&monitors, &triggers, &networks)?;
+                Ok(monitor)
+            }
+            None => Err(RepositoryError::load_error("Failed to load monitors", None, None)),
+        }
+    }
+
+    fn get(&self, monitor_id: &str) -> Option<Monitor> {
+        self.monitors.get(monitor_id).cloned()
+    }
+
+    fn get_all(&self) -> HashMap<String, Monitor> {
+        self.monitors.clone()
+    }
+}

--- a/src/repositories/db_network_repository.rs
+++ b/src/repositories/db_network_repository.rs
@@ -1,0 +1,63 @@
+use std::{collections::HashMap, env, path::Path};
+
+use async_trait::async_trait;
+use sqlx::{sqlite::SqlitePool, Row};
+
+use crate::{
+    models::Network,
+    repositories::{error::RepositoryError, NetworkRepositoryTrait},
+};
+
+/// Database-backed repository for network configurations
+#[derive(Clone)]
+pub struct DbNetworkRepository {
+    networks: HashMap<String, Network>,
+}
+
+impl DbNetworkRepository {
+    /// Compute the SQLite connection URL
+    fn db_url(path: Option<&Path>) -> String {
+        if let Some(p) = path {
+            format!("sqlite://{}", p.display())
+        } else if let Ok(url) = env::var("DATABASE_URL") {
+            url
+        } else {
+            "sqlite://monitor.db".to_string()
+        }
+    }
+}
+
+#[async_trait]
+impl NetworkRepositoryTrait for DbNetworkRepository {
+    async fn new(path: Option<&Path>) -> Result<Self, RepositoryError> {
+        let networks = Self::load_all(path).await?;
+        Ok(Self { networks })
+    }
+
+    async fn load_all(path: Option<&Path>) -> Result<HashMap<String, Network>, RepositoryError> {
+        let url = Self::db_url(path);
+        let pool = SqlitePool::connect(&url)
+            .await
+            .map_err(|e| RepositoryError::load_error("Failed to connect to database", Some(Box::new(e)), None))?;
+        let rows = sqlx::query("SELECT slug, data FROM networks")
+            .fetch_all(&pool)
+            .await
+            .map_err(|e| RepositoryError::load_error("Failed to load networks", Some(Box::new(e)), None))?;
+        let mut networks = HashMap::new();
+        for row in rows {
+            let slug: String = row.try_get("slug").map_err(|e| RepositoryError::load_error("Failed to load networks", Some(Box::new(e)), None))?;
+            let data: String = row.try_get("data").map_err(|e| RepositoryError::load_error("Failed to load networks", Some(Box::new(e)), None))?;
+            let network: Network = serde_json::from_str(&data).map_err(|e| RepositoryError::load_error("Failed to parse network", Some(Box::new(e)), None))?;
+            networks.insert(slug, network);
+        }
+        Ok(networks)
+    }
+
+    fn get(&self, network_id: &str) -> Option<Network> {
+        self.networks.get(network_id).cloned()
+    }
+
+    fn get_all(&self) -> HashMap<String, Network> {
+        self.networks.clone()
+    }
+}

--- a/src/repositories/db_trigger_repository.rs
+++ b/src/repositories/db_trigger_repository.rs
@@ -1,0 +1,62 @@
+use std::{collections::HashMap, env, path::Path};
+
+use async_trait::async_trait;
+use sqlx::{sqlite::SqlitePool, Row};
+
+use crate::{
+    models::Trigger,
+    repositories::{error::RepositoryError, TriggerRepositoryTrait},
+};
+
+/// Database-backed repository for trigger configurations
+#[derive(Clone)]
+pub struct DbTriggerRepository {
+    triggers: HashMap<String, Trigger>,
+}
+
+impl DbTriggerRepository {
+    fn db_url(path: Option<&Path>) -> String {
+        if let Some(p) = path {
+            format!("sqlite://{}", p.display())
+        } else if let Ok(url) = env::var("DATABASE_URL") {
+            url
+        } else {
+            "sqlite://monitor.db".to_string()
+        }
+    }
+}
+
+#[async_trait]
+impl TriggerRepositoryTrait for DbTriggerRepository {
+    async fn new(path: Option<&Path>) -> Result<Self, RepositoryError> {
+        let triggers = Self::load_all(path).await?;
+        Ok(Self { triggers })
+    }
+
+    async fn load_all(path: Option<&Path>) -> Result<HashMap<String, Trigger>, RepositoryError> {
+        let url = Self::db_url(path);
+        let pool = SqlitePool::connect(&url)
+            .await
+            .map_err(|e| RepositoryError::load_error("Failed to connect to database", Some(Box::new(e)), None))?;
+        let rows = sqlx::query("SELECT name, data FROM triggers")
+            .fetch_all(&pool)
+            .await
+            .map_err(|e| RepositoryError::load_error("Failed to load triggers", Some(Box::new(e)), None))?;
+        let mut triggers = HashMap::new();
+        for row in rows {
+            let name: String = row.try_get("name").map_err(|e| RepositoryError::load_error("Failed to load triggers", Some(Box::new(e)), None))?;
+            let data: String = row.try_get("data").map_err(|e| RepositoryError::load_error("Failed to load triggers", Some(Box::new(e)), None))?;
+            let trigger: Trigger = serde_json::from_str(&data).map_err(|e| RepositoryError::load_error("Failed to parse trigger", Some(Box::new(e)), None))?;
+            triggers.insert(name, trigger);
+        }
+        Ok(triggers)
+    }
+
+    fn get(&self, trigger_id: &str) -> Option<Trigger> {
+        self.triggers.get(trigger_id).cloned()
+    }
+
+    fn get_all(&self) -> HashMap<String, Trigger> {
+        self.triggers.clone()
+    }
+}

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -18,8 +18,14 @@ mod error;
 mod monitor;
 mod network;
 mod trigger;
+mod db_monitor_repository;
+mod db_network_repository;
+mod db_trigger_repository;
 
 pub use error::RepositoryError;
 pub use monitor::{MonitorRepository, MonitorRepositoryTrait, MonitorService};
 pub use network::{NetworkRepository, NetworkRepositoryTrait, NetworkService};
 pub use trigger::{TriggerRepository, TriggerRepositoryTrait, TriggerService};
+pub use db_monitor_repository::DbMonitorRepository;
+pub use db_network_repository::DbNetworkRepository;
+pub use db_trigger_repository::DbTriggerRepository;


### PR DESCRIPTION
## Summary
- support a SQLite backend with `sqlx`
- add `DbMonitorRepository`, `DbNetworkRepository` and `DbTriggerRepository`
- switch bootstrap to DB repositories when `SAAS_MODE=true`

## Testing
- `cargo fmt` *(fails: could not download Rust toolchain)*
- `cargo test -q` *(fails: could not download Rust toolchain)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading monitor, network, and trigger configurations from a SQLite database.
  - Application can now switch between file-based and database-backed repositories based on an environment variable.
- **Chores**
  - Updated dependencies to include database support.
- **Bug Fixes**
  - Improved error handling and validation when loading configurations from the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->